### PR TITLE
ops-build #1 change bb recipes to fetch modules from Mera repositories

### DIFF
--- a/yocto/openswitch/meta-distro-openswitch/recipes-ops/l3/ops-quagga.bb
+++ b/yocto/openswitch/meta-distro-openswitch/recipes-ops/l3/ops-quagga.bb
@@ -8,9 +8,9 @@ DEPENDS = "ops-utils ops-ovsdb ncurses perl-native openssl ops-supportability op
 # the "ip" command from busybox is not sufficient (flush by protocol flushes all routes)
 RDEPENDS_${PN} += "iproute2"
 
-BRANCH ?= "${OPS_REPO_BRANCH}"
+BRANCH ?= "meraswitch/master"
 
-SRC_URI = "${OPS_REPO_BASE_URL}/ops-quagga;protocol=${OPS_REPO_PROTOCOL};branch=${BRANCH} \
+SRC_URI = "git://git@github.com/MERAprojects/ops-quagga;protocol=ssh;branch=${BRANCH} \
     file://ops-zebra.service file://ops-bgpd.service file://ops-ospfd.service \
 "
 

--- a/yocto/openswitch/meta-distro-openswitch/recipes-ops/mgmt/ops-cli.bb
+++ b/yocto/openswitch/meta-distro-openswitch/recipes-ops/mgmt/ops-cli.bb
@@ -5,9 +5,9 @@ LIC_FILES_CHKSUM = "file://COPYING;md5=81bcece21748c91ba9992349a91ec11d\
 
 DEPENDS = "ops-utils ops-ovsdb"
 
-BRANCH ?= "${OPS_REPO_BRANCH}"
+BRANCH ?= "meraswitch/master"
 
-SRC_URI = "${OPS_REPO_BASE_URL}/ops-cli;protocol=${OPS_REPO_PROTOCOL};branch=${BRANCH} \
+SRC_URI = "git://git@github.com/MERAprojects/ops-cli;protocol=ssh;branch=${BRANCH} \
 "
 
 SRCREV = "571504f215e64e5d8b95b2492ccdd0f1daeff533"

--- a/yocto/openswitch/meta-distro-openswitch/recipes-ops/ops/ops.bb
+++ b/yocto/openswitch/meta-distro-openswitch/recipes-ops/ops/ops.bb
@@ -2,9 +2,9 @@ SUMMARY = "OpenSwitch"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/Apache-2.0;md5=89aea4e17d99a7cacdbeed46a0096b10"
 
-BRANCH ?= "${OPS_REPO_BRANCH}"
+BRANCH ?= "meraswitch/master"
 
-SRC_URI = "${OPS_REPO_BASE_URL}/ops;protocol=${OPS_REPO_PROTOCOL};branch=${BRANCH}"
+SRC_URI = "git://git@github.com/MERAprojects/ops;protocol=ssh;branch=${BRANCH}"
 
 SRCREV = "53a168fd72a7e691cd8b3b3428574f294551ef59"
 


### PR DESCRIPTION
Fix for #1. ops-quagga.bb, ops-cli.bb, ops.bb recipes will now fetch ops-quagga, ops-cli, ops repositories from Mera github using ssh (branch meraswitch/master).